### PR TITLE
fix(validator): 잘못된 조건문으로 인한 연산자 검증 실패 문제 해결

### DIFF
--- a/src/main/java/com/example/calculator/lv3/util/OperatorValidator.java
+++ b/src/main/java/com/example/calculator/lv3/util/OperatorValidator.java
@@ -7,6 +7,6 @@ public class OperatorValidator {
 
     public static void isValidOperator(String operator) {
         boolean isValid = Pattern.matches(OPERATOR_PATTERN, operator);
-        if (isValid) throw new IllegalArgumentException("지원하지 않는 연산자: "+ operator);
+        if (!isValid) throw new IllegalArgumentException("지원하지 않는 연산자: "+ operator);
     }
 }


### PR DESCRIPTION
유틸로 분리하는 과정에서 조건문의 방향이 잘못됨
유효한 연산자에 대해서도 예외가 발생하던 문제를 수정
조건문 수정으로, 잘못된 입력만 예외가 발생하도록 변경